### PR TITLE
Refactor/temporary database

### DIFF
--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -48,6 +48,12 @@ extern const int OK;                ///< SQLITE_OK (used by inline check() bello
 extern const char*  VERSION;        ///< SQLITE_VERSION string from the sqlite3.h used at compile time
 extern const int    VERSION_NUMBER; ///< SQLITE_VERSION_NUMBER from the sqlite3.h used at compile time
 
+// Private, temporary in-memory database.
+const std::string MEMORY = ":memory:";
+
+// Private, temporary on-disk database.
+const std::string TEMPORARY = "";
+
 /// Return SQLite version string using runtime call to the compiled library
 const char* getLibVersion() noexcept; // nothrow
 /// Return SQLite version number using runtime call to the compiled library
@@ -94,7 +100,7 @@ public:
      * @throw SQLite::Exception in case of error
      */
     Database(const char* apFilename,
-             const int   aFlags         = SQLite::OPEN_READONLY,
+             const int   aFlags,
              const int   aBusyTimeoutMs = 0,
              const char* apVfs          = nullptr);
 
@@ -116,9 +122,11 @@ public:
      * @throw SQLite::Exception in case of error
      */
     Database(const std::string& aFilename,
-             const int          aFlags          = SQLite::OPEN_READONLY,
+             const int          aFlags,
              const int          aBusyTimeoutMs  = 0,
              const std::string& aVfs            = "");
+
+    Database(std::string const &fileName = MEMORY);
 
     /**
      * @brief Close the SQLite database connection.
@@ -299,7 +307,7 @@ public:
     }
 
     /**
-     * @brief Create or redefine a SQL function or aggregate in the sqlite database. 
+     * @brief Create or redefine a SQL function or aggregate in the sqlite database.
      *
      *  This is the equivalent of the sqlite3_create_function_v2 command.
      * @see http://www.sqlite.org/c3ref/create_function.html
@@ -327,7 +335,7 @@ public:
                         void      (*apDestroy)(void *));
 
     /**
-     * @brief Create or redefine a SQL function or aggregate in the sqlite database. 
+     * @brief Create or redefine a SQL function or aggregate in the sqlite database.
      *
      *  This is the equivalent of the sqlite3_create_function_v2 command.
      * @see http://www.sqlite.org/c3ref/create_function.html
@@ -359,7 +367,7 @@ public:
     }
 
     /**
-     * @brief Load a module into the current sqlite database instance. 
+     * @brief Load a module into the current sqlite database instance.
      *
      *  This is the equivalent of the sqlite3_load_extension call, but additionally enables
      *  module loading support prior to loading the requested module.
@@ -378,8 +386,8 @@ public:
     /**
     * @brief Set the key for the current sqlite database instance.
     *
-    *  This is the equivalent of the sqlite3_key call and should thus be called 
-    *  directly after opening the database. 
+    *  This is the equivalent of the sqlite3_key call and should thus be called
+    *  directly after opening the database.
     *  Open encrypted database -> call db.key("secret") -> database ready
     *
     * @param[in] aKey   Key to decode/encode the database
@@ -407,10 +415,10 @@ public:
     /**
     * @brief Test if a file contains an unencrypted database.
     *
-    *  This is a simple test that reads the first bytes of a database file and 
-    *  compares them to the standard header for unencrypted databases. If the 
-    *  header does not match the standard string, we assume that we have an 
-    *  encrypted file. 
+    *  This is a simple test that reads the first bytes of a database file and
+    *  compares them to the standard header for unencrypted databases. If the
+    *  header does not match the standard string, we assume that we have an
+    *  encrypted file.
     *
     * @param[in] aFilename path/uri to a file
     *
@@ -436,6 +444,8 @@ private:
             throw SQLite::Exception(mpSQLite, aRet);
         }
     }
+
+    int open(std::string const &fileName, int const flags, int const busyTimeoutMs, std::string const &vfs);
 
 private:
     sqlite3*    mpSQLite;   ///< Pointer to SQLite Database Connection Handle

--- a/include/SQLiteCpp/Database.h
+++ b/include/SQLiteCpp/Database.h
@@ -126,7 +126,7 @@ public:
              const int          aBusyTimeoutMs  = 0,
              const std::string& aVfs            = "");
 
-    Database(std::string const &fileName = MEMORY);
+    Database(std::string const &fileName);
 
     /**
      * @brief Close the SQLite database connection.

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -84,7 +84,8 @@ Database::Database(const std::string& aFilename,
 
 // Open a temporary in-memory database by default, use SQLite::TEMPORARY to open a temporary on-disk database.
 Database::Database(string const &fileName) : mpSQLite(nullptr), mFilename(fileName) {
-  open(fileName, OPEN_READWRITE | OPEN_CREATE, 0, nullptr);
+  SQLITECPP_ASSERT(MEMORY == fileName || TEMPORARY == fileName, "Default access mode OPEN_READWRITE | OPEN_CREATE is only used for temporary databases");
+  open(fileName, OPEN_READWRITE | OPEN_CREATE, 0, "");
 }
 
 // Close the SQLite database connection.

--- a/src/examples/example1/main.cpp
+++ b/src/examples/example1/main.cpp
@@ -28,7 +28,7 @@ string const logoFileName = getFullPath("logo.png");
 class Example {
 public:
   // Constructor
-  Example() : m_db(dbFileName), m_query(m_db, "SELECT * FROM test WHERE weight > :min_weight") {
+  Example() : m_db(dbFileName, SQLite::OPEN_READONLY), m_query(m_db, "SELECT * FROM test WHERE weight > :min_weight") {
   }
 
   /// List the rows where the "weight" column is greater than the provided aParamValue
@@ -67,8 +67,7 @@ int main() {
 
   // Very basic first example (1/7)
   try {
-    // Open a database file in default readonly mode (SQLite::OPEN_READONLY)
-    SQLite::Database db(dbFileName);
+    SQLite::Database db(dbFileName, SQLite::OPEN_READONLY);
     cout << "SQLite database file '" << db.getFilename() << "' opened successfully\n";
 
     // Test if the 'test' table exists
@@ -84,8 +83,7 @@ int main() {
 
   // Simple select query - few variations (2/7)
   try {
-      // Open a database file in default readonly mode (SQLite::OPEN_READONLY)
-    SQLite::Database db(dbFileName);
+    SQLite::Database db(dbFileName, SQLite::OPEN_READONLY);
 
     // Loop to get values of column by index, using auto cast to variable type
     // Compile a SQL query, containing one parameter (index 1)
@@ -181,7 +179,7 @@ int main() {
 	// The execAndGet wrapper example (4/7)
 	try
 	{
-		SQLite::Database db(dbFileName);
+		SQLite::Database db(dbFileName, SQLite::OPEN_READONLY);
 
 		// WARNING: Be very careful with this dangerous method: you have to
 		// make a COPY OF THE result, else it will be destroy before the next line
@@ -194,7 +192,6 @@ int main() {
 
 	// Simple batch queries example (5/7)
 	try {
-		// Open a database file in create/write mode
 		SQLite::Database db("test.db3", SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE);
 		cout << "SQLite database file '" << db.getFilename() << "' opened successfully\n";
 
@@ -277,8 +274,10 @@ int main() {
 	remove("transaction.db3");
 
 	// Binary blob and in-memory database example (7/7)
+	cout << "Binary blob and in-memory database example (7/7)\n";
+
 	try {
-		SQLite::Database db(":memory:", SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE);
+		SQLite::Database db(SQLite::MEMORY);
 
 		db.exec("DROP TABLE IF EXISTS test");
 		db.exec("CREATE TABLE test (id INTEGER PRIMARY KEY, value BLOB)");
@@ -331,7 +330,7 @@ int main() {
 	// C++14 and Visual Studio 2015
 	// Example with C++14 variadic bind
 	try {
-		SQLite::Database db(":memory:", SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE);
+		SQLite::Database db(SQLite::MEMORY);
 
 		db.exec("DROP TABLE IF EXISTS test");
 		db.exec("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)");

--- a/src/tests/Database_test.cpp
+++ b/src/tests/Database_test.cpp
@@ -41,7 +41,7 @@ TEST(Database, ctorExecCreateDropExist) {
     {
         // Try to open a non-existing database
         std::string filename = "test.db3";
-        EXPECT_THROW(SQLite::Database not_found(filename), SQLite::Exception);
+        EXPECT_THROW(SQLite::Database not_found(filename, SQLite::OPEN_READONLY), SQLite::Exception);
 
         // Create a new database
         SQLite::Database db("test.db3", SQLite::OPEN_READWRITE|SQLite::OPEN_CREATE);
@@ -54,7 +54,7 @@ TEST(Database, ctorExecCreateDropExist) {
         EXPECT_TRUE(db.tableExists("test"));
         EXPECT_TRUE(db.tableExists(std::string("test")));
         EXPECT_EQ(0, db.getLastInsertRowid());
-        
+
         EXPECT_EQ(0, db.exec("DROP TABLE IF EXISTS test"));
         EXPECT_FALSE(db.tableExists("test"));
         EXPECT_FALSE(db.tableExists(std::string("test")));
@@ -67,7 +67,7 @@ TEST(Database, createCloseReopen) {
     remove("test.db3");
     {
         // Try to open the non-existing database
-        EXPECT_THROW(SQLite::Database not_found("test.db3"), SQLite::Exception);
+        EXPECT_THROW(SQLite::Database not_found("test.db3", SQLite::OPEN_READONLY), SQLite::Exception);
 
         // Create a new database
         SQLite::Database db("test.db3", SQLite::OPEN_READWRITE|SQLite::OPEN_CREATE);
@@ -86,17 +86,17 @@ TEST(Database, createCloseReopen) {
 TEST(Database, inMemory) {
     {
         // Create a new database
-        SQLite::Database db(":memory:", SQLite::OPEN_READWRITE);
+        SQLite::Database db(SQLite::MEMORY);
         EXPECT_FALSE(db.tableExists("test"));
         db.exec("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)");
         EXPECT_TRUE(db.tableExists("test"));
         // Create a new database: not shared with the above db
-        SQLite::Database db2(":memory:");
+        SQLite::Database db2(SQLite::MEMORY);
         EXPECT_FALSE(db2.tableExists("test"));
     } // Close an destroy DBs
     {
         // Create a new database: no more "test" table
-        SQLite::Database db(":memory:");
+        SQLite::Database db(SQLite::MEMORY);
         EXPECT_FALSE(db.tableExists("test"));
     } // Close an destroy DB
 }
@@ -105,7 +105,7 @@ TEST(Database, inMemory) {
 TEST(Database, busyTimeout) {
     {
         // Create a new database with default timeout of 0ms
-        SQLite::Database db(":memory:");
+        SQLite::Database db(SQLite::MEMORY);
         // Busy timeout default to 0ms: any contention between threads or process leads to SQLITE_BUSY error
         EXPECT_EQ(0, db.execAndGet("PRAGMA busy_timeout").getInt());
 
@@ -119,7 +119,7 @@ TEST(Database, busyTimeout) {
     }
     {
         // Create a new database with a non null busy timeout
-        SQLite::Database db(":memory:", SQLite::OPEN_READWRITE, 5000);
+        SQLite::Database db(SQLite::MEMORY, SQLite::OPEN_READWRITE, 5000);
         EXPECT_EQ(5000, db.execAndGet("PRAGMA busy_timeout").getInt());
 
         // Reset timeout to null
@@ -128,8 +128,7 @@ TEST(Database, busyTimeout) {
     }
     {
         // Create a new database with a non null busy timeout
-        const std::string memory = ":memory:";
-        SQLite::Database db(memory, SQLite::OPEN_READWRITE, 5000);
+        SQLite::Database db(SQLite::MEMORY, SQLite::OPEN_READWRITE, 5000);
         EXPECT_EQ(5000, db.execAndGet("PRAGMA busy_timeout").getInt());
 
         // Reset timeout to null
@@ -141,7 +140,7 @@ TEST(Database, busyTimeout) {
 
 TEST(Database, exec) {
     // Create a new database
-    SQLite::Database db(":memory:", SQLite::OPEN_READWRITE);
+    SQLite::Database db(SQLite::MEMORY);
 
     // Create a new table with an explicit "id" column aliasing the underlying rowid
     // NOTE: here exec() returns 0 only because it is the first statements since database connexion,
@@ -202,7 +201,7 @@ TEST(Database, exec) {
 
 TEST(Database, execAndGet) {
     // Create a new database
-    SQLite::Database db(":memory:", SQLite::OPEN_READWRITE);
+    SQLite::Database db(SQLite::MEMORY);
 
     // Create a new table with an explicit "id" column aliasing the underlying rowid
     db.exec("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT, weight INTEGER)");
@@ -220,7 +219,7 @@ TEST(Database, execAndGet) {
 
 TEST(Database, execException) {
     // Create a new database
-    SQLite::Database db(":memory:", SQLite::OPEN_READWRITE);
+    SQLite::Database db(SQLite::MEMORY);
     EXPECT_EQ(SQLite::OK, db.getErrorCode());
     EXPECT_EQ(SQLite::OK, db.getExtendedErrorCode());
 
@@ -264,7 +263,7 @@ TEST(Database, encryptAndDecrypt) {
     remove("test.db3");
     {
         // Try to open the non-existing database
-        EXPECT_THROW(SQLite::Database not_found("test.db3"), SQLite::Exception);
+        EXPECT_THROW(SQLite::Database not_found("test.db3", SQLite::OPEN_READONLY), SQLite::Exception);
 
         // Create a new database
         SQLite::Database db("test.db3", SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE);
@@ -308,7 +307,7 @@ TEST(Database, encryptAndDecrypt) {
     remove("test.db3");
     {
         // Try to open the non-existing database
-        EXPECT_THROW(SQLite::Database not_found("test.db3"), SQLite::Exception);
+        EXPECT_THROW(SQLite::Database not_found("test.db3", SQLite::OPEN_READONLY), SQLite::Exception);
 
         // Create a new database
         SQLite::Database db("test.db3", SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE);


### PR DESCRIPTION
Close #5 

Remove default access mode in ctors.

Open temporary databases easily:

```c++
SQLite::Database db(SQLite::MEMORY); // in memory temporary
SQLite::Database db(SQLite::TEMPORARY); // on disk temporary
```